### PR TITLE
Allow disabling RPC server TLS for localhost only.

### DIFF
--- a/doc.go
+++ b/doc.go
@@ -48,6 +48,8 @@ Application Options:
       --norpc              Disable built-in RPC server -- NOTE: The RPC server
                            is disabled by default if no rpcuser/rpcpass is
                            specified
+      --notls              Disable TLS for the RPC server -- NOTE: This is only
+                           allowed if the RPC server is bound to localhost
       --nodnsseed          Disable DNS seeding for peers
       --externalip:        Add an ip to the list of local addresses we claim to
                            listen on to peers

--- a/sample-btcd.conf
+++ b/sample-btcd.conf
@@ -193,6 +193,11 @@
 ; server without having to remove credentials from the config file.
 ; norpc=1
 
+; Use the following setting to disable TLS for the RPC server.  NOTE: This
+; option only works if the RPC server is bound to localhost interfaces (which is
+; the default).
+; notls=1
+
 
 ; ------------------------------------------------------------------------------
 ; Coin Generation (Mining) Settings - The following options control the


### PR DESCRIPTION
This pull request introduces a new flag, `--notls`, which can be used to disable TLS for the RPC server.  However, the flag can only be used when the RPC server is bound to localhost interfaces.  This is intended to prevent the situation where someone decides they want to expose the RPC server to the web for remote management/access, but forgot they have TLS disabled.

Here is an example of the functionality:

**Disallowed**

> $ ./btcd --notls --rpclisten=whateverdomain.com
> loadConfig: the --notls option may not be used when binding to non localhost addresses: whateverdomain.com:8334
> Use btcd -h to show usage
> 
> $ ./btcd --notls --rpclisten=whateverdomain.com:12345
> loadConfig: the --notls option may not be used when binding to non localhost addresses: whateverdomain.com:12345
> Use btcd -h to show usage
> 
> $ ./btcd --notls --rpclisten=1.2.3.4
> loadConfig: the --notls option may not be used when binding to non localhost addresses: 1.2.3.4:8334
> Use btcd -h to show usage
> 
> $ ./btcd --notls --rpclisten=1.2.3.4:12345
> loadConfig: the --notls option may not be used when binding to non localhost addresses: 1.2.3.4:12345
> Use btcd -h to show usage
> 
> $ ./btcd --notls --rpclisten=1234::1234
> loadConfig: the --notls option may not be used when binding to non localhost addresses: [1234::1234]:8334
> Use btcd -h to show usage
> 
> $ ./btcd --notls --rpclisten=[1234::1234]:12345
> loadConfig: the --notls option may not be used when binding to non localhost addresses: [1234::1234]:12345
> Use btcd -h to show usage
> 

**Allowed**

> $ ./btcd --notls
> 17:31:44 2014-12-20 [INF] BTCD: Version 0.9.0-beta
>
> $ ./btcd --notls --rpclisten=localhost
> 17:31:49 2014-12-20 [INF] BTCD: Version 0.9.0-beta
> 
> $ ./btcd --notls --rpclisten=localhost:12345
> 17:31:52 2014-12-20 [INF] BTCD: Version 0.9.0-beta
> 
> $ ./btcd --notls --rpclisten=127.0.0.1
> 17:32:09 2014-12-20 [INF] BTCD: Version 0.9.0-beta
> 
> $ ./btcd --notls --rpclisten=127.0.0.1:12345
> 17:32:13 2014-12-20 [INF] BTCD: Version 0.9.0-beta
> 
> $ ./btcd --notls --rpclisten=::1
> 17:32:16 2014-12-20 [INF] BTCD: Version 0.9.0-beta
> 
> $ ./btcd --notls --rpclisten=[::1]:12345
> 17:32:20 2014-12-20 [INF] BTCD: Version 0.9.0-beta