### PR TITLE
Improve double spend error strings.

### DIFF
--- a/blockmanager.go
+++ b/blockmanager.go
@@ -1176,7 +1176,8 @@ func (b *blockManager) handleNotifyMsg(notification *btcchain.Notification) {
 		// Reinsert all of the transactions (except the coinbase) into
 		// the transaction pool.
 		for _, tx := range block.Transactions()[1:] {
-			err := b.server.txMemPool.MaybeAcceptTransaction(tx, nil, false, true)
+			_, err := b.server.txMemPool.MaybeAcceptTransaction(tx,
+				false, true)
 			if err != nil {
 				// Remove the transaction and all transactions
 				// that depend on it if it wasn't accepted into

--- a/log.go
+++ b/log.go
@@ -30,7 +30,7 @@ const (
 
 	// maxRejectReasonLen is the maximum length of a sanitized reject reason
 	// that will be logged.
-	maxRejectReasonLen = 200
+	maxRejectReasonLen = 250
 )
 
 // Loggers per subsytem.  Note that backendLog is a seelog logger that all of


### PR DESCRIPTION
The mempool's MaybeAcceptTransaction methods have also been modified
to return a slice of transaction hashes referenced by the transaction
inputs which are unknown (totally spent or never seen).  While this is
currently used to include the first hash in a ProcessTransaction error
message if inserting orphans is not allowed, it may also be used in
the future to request orphan transactions from peers.