### PR TITLE
Correct sample-btcd.conf RPC listen comment.

### DIFF
--- a/sample-btcd.conf
+++ b/sample-btcd.conf
@@ -156,8 +156,9 @@
 ; Specify the interfaces for the RPC server listen on.  One listen address per
 ; line.  NOTE: The default port is modified by some options such as 'testnet',
 ; so it is recommended to not specify a port and allow a proper default to be
-; chosen unless you have a specific reason to do otherwise.
-; All interfaces on default port (this is the default):
+; chosen unless you have a specific reason to do otherwise.  By default, the
+; RPC server will only listen on localhost for IPv4 and IPv6.
+; All interfaces on default port:
 ;   rpclisten=
 ; All ipv4 interfaces on default port:
 ;   rpclisten=0.0.0.0


### PR DESCRIPTION
The comment for the RPC listen section in the sample-btcd.conf incorrectly claimed that the default for the RPC server listener is to listen on all interfaces by default.  In reality, it only listens on localhost for IPv4 and IPv6 by default.

Closes #208.